### PR TITLE
Add methods for toggler attributes, classes, and CSS styles in `Accordion`.

### DIFF
--- a/docs/guide/en/accordion.md
+++ b/docs/guide/en/accordion.md
@@ -106,8 +106,26 @@ Add custom attributes or classes to the toggler:
 
 ```php
 $accordion = Accordion::widget()
-    ->togglerAttributes(['data-action' => 'toggle'])
-    ->addClass('bg-light');
+    ->addClass('bg-light')
+    ->togglerAttributes(['data-action' => 'toggle']);
+```
+
+Add attribute to the toggler:
+
+```php
+$accordion = Accordion::widget()->addTogglerAttribute(['data-id' => '123']);
+```
+
+Add class to the toggler:
+
+```php
+$accordion = Accordion::widget()->addTogglerClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY);
+```
+
+Add style to the toggler:
+
+```php
+$accordion = Accordion::widget()->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);
 ```
 
 ### Always Open Behavior

--- a/docs/guide/en/accordion.md
+++ b/docs/guide/en/accordion.md
@@ -102,27 +102,19 @@ Change the toggler tag (defaults to `button`):
 $accordion = Accordion::widget()->togglerTag('div');
 ```
 
-Add custom attributes or classes to the toggler:
-
-```php
-$accordion = Accordion::widget()
-    ->addClass('bg-light')
-    ->togglerAttributes(['data-action' => 'toggle']);
-```
-
-Add attribute to the toggler:
+Add attribute:
 
 ```php
 $accordion = Accordion::widget()->addTogglerAttribute(['data-id' => '123']);
 ```
 
-Add class to the toggler:
+Add class:
 
 ```php
 $accordion = Accordion::widget()->addTogglerClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY);
 ```
 
-Add style to the toggler:
+Add style:
 
 ```php
 $accordion = Accordion::widget()->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -55,7 +55,7 @@ final class Accordion extends Widget
     /**
      * Adds a sets of attributes.
      *
-     * @param array $attributes Attribute values indexed by attribute names. e.g. `['id' => 'my-id']`.
+     * @param array $attributes Attribute values indexed by attribute names. for example, `['id' => 'my-id']`.
      *
      * @return self A new instance with the specified attributes added.
      *
@@ -100,9 +100,9 @@ final class Accordion extends Widget
     /**
      * Adds a CSS style.
      *
-     * @param array|string $style The CSS style. If an array, the values will be separated by a space. If a string, it
-     * will be added as is. For example, `color: red`. If the value is an array, the values will be separated by a
-     * space. e.g., `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * @param array|string $style The CSS style. If the value is an array, a space will separate the values.
+     * for example, `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * If it is a string, it will be added as is, for example, `color: red`.
      * @param bool $overwrite Whether to overwrite existing styles with the same name. If `false`, the new value will be
      * appended to the existing one.
      *
@@ -120,6 +120,82 @@ final class Accordion extends Widget
     {
         $new = clone $this;
         Html::addCssStyle($new->attributes, $style, $overwrite);
+
+        return $new;
+    }
+
+    /**
+     * Adds a sets attribute value.
+     *
+     * @param string $name The attribute name.
+     * @param mixed $value The attribute value.
+     *
+     * @return self A new instance with the specified attribute added.
+     *
+     * Example usage:
+     * ```php
+     * $accordion->addTogglerAttribute('data-id', '123');
+     * ```
+     */
+    public function addTogglerAttribute(string $name, mixed $value): self
+    {
+        $new = clone $this;
+        $new->togglerAttributes[$name] = $value;
+
+        return $new;
+    }
+
+    /**
+     * Adds one or more CSS classes to the existing classes.
+     *
+     * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
+     * automatically.
+     *
+     * @param BackedEnum|string|null ...$class One or more CSS class names to add. Pass `null` to skip adding a class.
+     *
+     * @return self A new instance with the specified CSS classes added to existing ones.
+     *
+     * @link https://html.spec.whatwg.org/#classes
+     *
+     * Example usage:
+     * ```php
+     * $accordion->addTogglerClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY);
+     * ```
+     */
+    public function addTogglerClass(BackedEnum|string|null ...$class): self
+    {
+        $new = clone $this;
+
+        foreach ($class as $item) {
+            Html::addCssClass($new->togglerAttributes, $item);
+        }
+
+        return $new;
+    }
+
+    /**
+     * Adds a CSS style.
+     *
+     * @param array|string $style The CSS style. If the value is an array, a space will separate the values.
+     * for example, `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * If it is a string, it will be added as is, for example, `color: red`.
+     * @param bool $overwrite Whether to overwrite existing styles with the same name. If `false`, the new value will be
+     * appended to the existing one.
+     *
+     * @return self A new instance with the specified CSS style value added.
+     *
+     * Example usage:
+     * ```php
+     * $accordion->addTogglerCssStyle('color: red');
+     *
+     * // or
+     * $accordion->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);
+     * ```
+     */
+    public function addTogglerCssStyle(array|string $style, bool $overwrite = true): self
+    {
+        $new = clone $this;
+        Html::addCssStyle($new->togglerAttributes, $style, $overwrite);
 
         return $new;
     }

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -193,6 +193,179 @@ final class AccordionTest extends TestCase
         );
     }
 
+    public function testAddTogglerAttribute(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed" data-id="123" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            Accordion::widget()
+                ->id('accordion')
+                ->items(
+                    AccordionItem::to('Accordion Item #1', "This is the first item's accordion body.", 'accordion-1'),
+                )
+                ->addTogglerAttribute('data-id', '123')
+                ->render(),
+        );
+    }
+
+    public function testAddTogglerClass(): void
+    {
+        $accordion = Accordion::widget()
+            ->addTogglerClass('test-class', null, BackgroundColor::PRIMARY)
+            ->id('accordion')
+            ->items(AccordionItem::to('Accordion Item #1', "This is the first item's accordion body.", 'accordion-1'));
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed test-class bg-primary" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed test-class bg-primary test-class-1 test-class-2" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->addTogglerClass('test-class-1', 'test-class-2')->render(),
+        );
+    }
+
+    public function testAddTogglerCssStyle(): void
+    {
+        $accordion = Accordion::widget()
+            ->id('accordion')
+            ->items(AccordionItem::to('Accordion Item #1', "This is the first item's accordion body.", 'accordion-1'))
+            ->addTogglerCssStyle('color: red;');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed" style="color: red;" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed" style="color: red; font-weight: bold;" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->addTogglerCssStyle('font-weight: bold;')->render(),
+        );
+    }
+
+    public function testAddTogglerCssStyleWithOverwriteFalse(): void
+    {
+        $accordion = Accordion::widget()
+            ->id('accordion')
+            ->items(AccordionItem::to('Accordion Item #1', "This is the first item's accordion body.", 'accordion-1'))
+            ->addTogglerCssStyle('color: red;');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed" style="color: red;" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div id="accordion" class="accordion">
+            <div class="accordion-item">
+            <h2 class="accordion-header">
+            <button type="button" class="accordion-button collapsed" style="color: red;" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
+            Accordion Item #1
+            </button>
+            </h2>
+            <div id="accordion-1" class="accordion-collapse collapse" data-bs-parent="#accordion">
+            <div class="accordion-body">
+            This is the first item's accordion body.
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML,
+            $accordion->addTogglerCssStyle('color: blue;', false)->render(),
+        );
+    }
+
     public function testAttribute(): void
     {
         Assert::equalsWithoutLE(
@@ -717,6 +890,9 @@ final class AccordionTest extends TestCase
         $this->assertNotSame($accordion, $accordion->addAttributes([]));
         $this->assertNotSame($accordion, $accordion->addClass(''));
         $this->assertNotSame($accordion, $accordion->addCssStyle(''));
+        $this->assertNotSame($accordion, $accordion->addTogglerAttribute('', ''));
+        $this->assertNotSame($accordion, $accordion->addTogglerClass(''));
+        $this->assertNotSame($accordion, $accordion->addTogglerCssStyle(''));
         $this->assertNotSame($accordion, $accordion->alwaysOpen());
         $this->assertNotSame($accordion, $accordion->attribute('', ''));
         $this->assertNotSame($accordion, $accordion->attributes([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
