### PR TITLE
Enhance `Dropdown` widget: add methods for toggler attributes, classes, and styles in documentation and implementation.

### DIFF
--- a/docs/guide/en/dropdown.md
+++ b/docs/guide/en/dropdown.md
@@ -89,25 +89,19 @@ $dropdown = Dropdown::widget()
     ->togglerContent('Options');
 ```
 
-Add custom attributes to the toggler:
-
-```php
-$dropdown = Dropdown::widget()->togglerAttributes(['data-action' => 'toggle']);
-```
-
-Add attribute to the toggler:
+Add attribute:
 
 ```php
 $dropdown = Dropdown::widget()->addTogglerAttribute(['data-id' => '123']);
 ```
 
-Add class to the toggler:
+Add class:
 
 ```php
 $dropdown = Dropdown::widget()->addTogglerClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY);
 ```
 
-Add style to the toggler:
+Add style:
 
 ```php
 $dropdown = Dropdown::widget()->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);

--- a/docs/guide/en/dropdown.md
+++ b/docs/guide/en/dropdown.md
@@ -89,6 +89,32 @@ $dropdown = Dropdown::widget()
     ->togglerContent('Options');
 ```
 
+Add custom attributes or classes to the toggler:
+
+```php
+$dropdown = Dropdown::widget()
+    ->addClass('bg-light')
+    ->togglerAttributes(['data-action' => 'toggle']);
+```
+
+Add attribute to the toggler:
+
+```php
+$dropdown = Dropdown::widget()->addTogglerAttribute(['data-id' => '123']);
+```
+
+Add class to the toggler:
+
+```php
+$dropdown = Dropdown::widget()->addTogglerClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY);
+```
+
+Add style to the toggler:
+
+```php
+$dropdown = Dropdown::widget()->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);
+```
+
 ### Direction and Alignment
 Set the dropdown direction with `direction()`:
 

--- a/docs/guide/en/dropdown.md
+++ b/docs/guide/en/dropdown.md
@@ -89,12 +89,10 @@ $dropdown = Dropdown::widget()
     ->togglerContent('Options');
 ```
 
-Add custom attributes or classes to the toggler:
+Add custom attributes to the toggler:
 
 ```php
-$dropdown = Dropdown::widget()
-    ->addClass('bg-light')
-    ->togglerAttributes(['data-action' => 'toggle']);
+$dropdown = Dropdown::widget()->togglerAttributes(['data-action' => 'toggle']);
 ```
 
 Add attribute to the toggler:

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -76,7 +76,7 @@ final class Dropdown extends Widget
     /**
      * Adds a sets of attributes.
      *
-     * @param array $attributes Attribute values indexed by attribute names. e.g. `['id' => 'my-id']`.
+     * @param array $attributes Attribute values indexed by attribute names. for example, `['id' => 'my-id']`.
      *
      * @return self A new instance with the specified attributes added.
      *
@@ -121,9 +121,9 @@ final class Dropdown extends Widget
     /**
      * Adds a CSS style.
      *
-     * @param array|string $style The CSS style. If an array, the values will be separated by a space. If a string, it
-     * will be added as is. For example, `color: red`. If the value is an array, the values will be separated by a
-     * space. e.g., `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * @param array|string $style The CSS style. If the value is an array, a space will separate the values.
+     * For example, `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * If it is a string, it will be added as is, for example, `color: red`.
      * @param bool $overwrite Whether to overwrite existing styles with the same name. If `false`, the new value will be
      * appended to the existing one.
      *
@@ -146,27 +146,28 @@ final class Dropdown extends Widget
     }
 
     /**
-     * Adds a set of attributes for the toggler button.
+     * Adds toggler attribute value.
      *
-     * @param array $attributes Attribute values indexed by attribute names. e.g. `['id' => 'my-id']`.
+     * @param string $name The attribute name.
+     * @param mixed $value The attribute value.
      *
-     * @return self A new instance with the specified attributes for the toggler button.
+     * @return self A new instance with the specified attribute added.
      *
      * Example usage:
      * ```php
-     * $dropdown->addTogglerAttributes(['data-id' => '123']);
+     * $dropdown->addTogglerAttribute('data-id', '123');
      * ```
      */
-    public function addTogglerAttributes(array $attributes): self
+    public function addTogglerAttribute(string $name, mixed $value): self
     {
         $new = clone $this;
-        $new->togglerAttributes = [...$this->togglerAttributes, ...$attributes];
+        $new->togglerAttributes[$name] = $value;
 
         return $new;
     }
 
     /**
-     * Adds one or more CSS classes to the existing classes.
+     * Adds one or more CSS classes to the existing toggler classes.
      *
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
@@ -189,6 +190,33 @@ final class Dropdown extends Widget
         foreach ($class as $item) {
             Html::addCssClass($new->togglerAttributes, $item);
         }
+
+        return $new;
+    }
+
+    /**
+     * Adds a toggler CSS style.
+     *
+     * @param array|string $style The CSS style. If the value is an array, a space will separate the values.
+     * for example, `['color' => 'red', 'font-weight' => 'bold']` will be rendered as `color: red; font-weight: bold;`.
+     * If it is a string, it will be added as is, for example, `color: red`.
+     * @param bool $overwrite Whether to overwrite existing styles with the same name. If `false`, the new value will be
+     * appended to the existing one.
+     *
+     * @return self A new instance with the specified CSS style value added.
+     *
+     * Example usage:
+     * ```php
+     * $drodown->addTogglerCssStyle('color: red');
+     *
+     * // or
+     * $dropdown->addTogglerCssStyle(['color' => 'red', 'font-weight' => 'bold']);
+     * ```
+     */
+    public function addTogglerCssStyle(array|string $style, bool $overwrite = true): self
+    {
+        $new = clone $this;
+        Html::addCssStyle($new->togglerAttributes, $style, $overwrite);
 
         return $new;
     }
@@ -271,7 +299,7 @@ final class Dropdown extends Widget
      */
     public function autoClose(DropdownAutoClose $autoClose): self
     {
-        return $this->addTogglerAttributes(['data-bs-auto-close' => $autoClose->value]);
+        return $this->addTogglerAttribute('data-bs-auto-close', $autoClose->value);
     }
 
     /**

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -390,7 +390,6 @@ final class DropdownTest extends TestCase
         );
     }
 
-
     /**
      * @link https://getbootstrap.com/docs/5.3/components/dropdowns/#alignment-options
      */

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -207,6 +207,36 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testAddTogglerAttribute(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" class="btn btn-secondary dropdown-toggle" data-id="123" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->addTogglerAttribute('data-id', '123')
+                ->items(
+                    DropdownItem::link('Action', '#'),
+                    DropdownItem::link('Another action', '#'),
+                    DropdownItem::link('Something else here', '#'),
+                )
+                ->render(),
+        );
+    }
+
     public function testAddTogglerClass(): void
     {
         $dropdownWidget = Dropdown::widget()
@@ -257,6 +287,109 @@ final class DropdownTest extends TestCase
             $dropdownWidget->addTogglerClass('test-class-1', 'test-class-2')->render(),
         );
     }
+
+    public function testAddTogglerCssStyle(): void
+    {
+        $dropdown = Dropdown::widget()
+            ->addTogglerCssStyle('color: red;')
+            ->items(
+                DropdownItem::link('Action', '#'),
+                DropdownItem::link('Another action', '#'),
+                DropdownItem::link('Something else here', '#'),
+            );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" class="btn btn-secondary dropdown-toggle" style="color: red;" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            $dropdown->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" class="btn btn-secondary dropdown-toggle" style="color: red; font-weight: bold;" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            $dropdown->addTogglerCssStyle('font-weight: bold;')->render(),
+        );
+    }
+
+    public function testAddTogglerCssStyleWithOverwriteFalse(): void
+    {
+        $dropdown = Dropdown::widget()
+            ->addTogglerCssStyle('color: red;')
+            ->items(
+                DropdownItem::link('Action', '#'),
+                DropdownItem::link('Another action', '#'),
+                DropdownItem::link('Something else here', '#'),
+            );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" class="btn btn-secondary dropdown-toggle" style="color: red;" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            $dropdown->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" class="btn btn-secondary dropdown-toggle" style="color: red;" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            $dropdown->addTogglerCssStyle('color: blue;', false)->render(),
+        );
+    }
+
 
     /**
      * @link https://getbootstrap.com/docs/5.3/components/dropdowns/#alignment-options
@@ -1111,6 +1244,9 @@ final class DropdownTest extends TestCase
         $this->assertNotSame($dropdownWidget, $dropdownWidget->addAttributes([]));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->addClass(''));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->addCssStyle([]));
+        $this->assertNotSame($dropdownWidget, $dropdownWidget->addTogglerAttribute('', ''));
+        $this->assertNotSame($dropdownWidget, $dropdownWidget->addTogglerClass(''));
+        $this->assertNotSame($dropdownWidget, $dropdownWidget->addTogglerCssStyle([]));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->alignment(DropdownAlignment::END));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->attribute('', ''));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->attributes([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
