### PR TITLE
Raise code coverage `100%` in `Dropdown` class.

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -683,13 +683,13 @@ final class Dropdown extends Widget
         $classes = $attributes['class'] ?? null;
         $containerClasses = $this->containerClasses;
 
-        unset($attributes['class']);
-
         if ($this->items === []) {
             return '';
         }
 
         $togglerId = $this->getTogglerId();
+
+        unset($attributes['class'], $attributes['id']);
 
         if ($this->togglerSplit) {
             $containerClasses = [self::DROPDOWN_TOGGLER_CONTAINER_CLASS];

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -1988,6 +1988,37 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testTogglerIdWithTrueValue(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="dropdown">
+            <button type="button" id="test-id" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown button</button>
+            <ul class="dropdown-menu" aria-labelledby="test-id">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->attributes(['id' => 'test-id'])
+                ->items(
+                    DropdownItem::link('Action', '#'),
+                    DropdownItem::link('Another action', '#'),
+                    DropdownItem::link('Something else here', '#'),
+                )
+                ->togglerId(true)
+                ->render(),
+        );
+    }
+
     public function testTogglerSizeLarge(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
