### PR TITLE
Raise code coverage `100%` in `NavLink` class.

### DIFF
--- a/tests/NavLinkTest.php
+++ b/tests/NavLinkTest.php
@@ -21,6 +21,7 @@ final class NavLinkTest extends TestCase
 
         $this->assertNotSame($navLink, $navLink->active(false));
         $this->assertNotSame($navLink, $navLink->attributes([]));
+        $this->assertNotSame($navLink, $navLink->content(''));
         $this->assertNotSame($navLink, $navLink->disabled(false));
         $this->assertNotSame($navLink, $navLink->encodeContent(false));
         $this->assertNotSame($navLink, $navLink->encodeLabel(false));

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -755,15 +755,15 @@ final class NavTest extends TestCase
             </ul>
             HTML,
             Nav::widget()
-            ->attributes(['id' => 'test-id'])
-            ->id(true)
-            ->items(
-                NavLink::to('Active', '#', active: true),
-                NavLink::to('Link', url: '#'),
-                NavLink::to('Link', url: '#'),
-                NavLink::to('Disabled', '#', disabled: true),
-            )
-            ->render(),
+                ->attributes(['id' => 'test-id'])
+                ->id(true)
+                ->items(
+                    NavLink::to('Active', '#', active: true),
+                    NavLink::to('Link', url: '#'),
+                    NavLink::to('Link', url: '#'),
+                    NavLink::to('Disabled', '#', disabled: true),
+                )
+                ->render(),
         );
     }
 
@@ -1122,6 +1122,33 @@ final class NavTest extends TestCase
                 )
                 ->styles(NavStyle::TABS)
             ->render(),
+        );
+    }
+
+    public function testTabPaneWithSetIDPaneAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="nav nav-tabs" role="tablist">
+            <li class="nav-item" role="presentation">
+            <button type="button" id="test1" class="nav-link active" data-bs-toggle="tab" data-bs-target="#test1-pane" role="tab" aria-controls="test1-pane" aria-selected="true">title1</button>
+            </li>
+            <li class="nav-item" role="presentation">
+            <button type="button" id="test2" class="nav-link" data-bs-toggle="tab" data-bs-target="#test2-pane" role="tab" aria-controls="test2-pane" aria-selected="false">title2</button>
+            </li>
+            </ul>
+            <div class="tab-content">
+            <div id="test1-pane" class="tab-pane fade show active" role="tabpanel" aria-labelledby="test1" tabindex="0">Some HTML</div>
+            <div id="test2-pane" class="tab-pane fade" role="tabpanel" aria-labelledby="test2" tabindex="0">Some HTML</div>
+            </div>
+            HTML,
+            Nav::widget()
+                ->items(
+                    NavLink::tab('title1', 'Some HTML', true, paneAttributes: ['id' => 'test1']),
+                    NavLink::tab('title2', 'Some HTML', false, paneAttributes: ['id' => 'test2']),
+                )
+                ->styles(NavStyle::TABS)
+                ->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
