### PR TITLE
Fix #309: Fix `Collapse` re-encoding content already managed by `Toggler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #306: Raise `yiisoft/html` version to `^3.13 || ^4.0` (@vjik)
 - New #305: Add `tabIndex()` method to `Button` widget (@Mister-42)
+- Bug #309: Fix `Collapse` re-encoding content already managed by `Toggler` (@vjik)
 
 ## 1.1.0 March 06, 2026
 

--- a/src/Collapse.php
+++ b/src/Collapse.php
@@ -362,14 +362,9 @@ final class Collapse extends Widget
                     ->addAttributes($this->attributes)
                     ->addContent(
                         "\n",
-                        (new Div())
-                            ->addAttributes($this->cardBodyAttributes)
+                        Html::div("\n" . $item->getContent() . "\n", $this->cardBodyAttributes)
                             ->addClass(self::CARD, self::CARD_BODY)
-                            ->addContent(
-                                "\n",
-                                $item->getContent(),
-                                "\n",
-                            ),
+                            ->encode(false),
                         "\n",
                     )
                     ->id($item->getId());

--- a/tests/CollapseTest.php
+++ b/tests/CollapseTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Bootstrap5\Tests;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Bootstrap5\Collapse;
 use Yiisoft\Bootstrap5\Tests\Support\Assert;
@@ -474,5 +475,15 @@ final class CollapseTest extends TestCase
                 ->togglerContainerTag('div')
                 ->render(),
         );
+    }
+
+    #[TestWith(['&lt;b&gt;Bold content&lt;/b&gt;', true])]
+    #[TestWith(['<b>Bold content</b>', false])]
+    public function testTogglerHtmlContent(string $expected, bool $encode): void
+    {
+        $toggler = Toggler::for('<b>Bold content</b>', 'collapseExample', encode: $encode)->togglerContent('Toggle');
+        $widget = Collapse::widget()->items($toggler);
+
+        $this->assertStringContainsString($expected, $widget->render());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
Fix #309 